### PR TITLE
TZ - add paddle shade

### DIFF
--- a/public/game/gameObjects.js
+++ b/public/game/gameObjects.js
@@ -3,15 +3,20 @@ import { BoxCollider, MeshCollider3D } from '../physics/collider.js';
 import { Vec3 } from '../physics/math.js';
 import { RigidBody } from '../physics/engine.js';
 import { KeyboardController } from './controllers.js';
+import { paddleFragmentShader, paddleVertexShader } from './paddleShader.js';
 import { BodyForceApplier } from '../physics/forces.js';
 
 export class Paddle {
 	// Square paddle
 	constructor(meshSettings, controller = new KeyboardController('yz')) {
-		const geometry = new THREE.EdgesGeometry(new THREE.BoxGeometry(0.5, 3, 3));
-        const material = new THREE.LineBasicMaterial(meshSettings);
+		const geometry = new THREE.BoxGeometry(0.5, 3, 3);
+		const material = new THREE.ShaderMaterial({
+			vertexShader: paddleVertexShader,
+			fragmentShader: paddleFragmentShader,
+			transparent: false
+		});
 
-		this.visual = new THREE.LineSegments(geometry, material);
+		this.visual = new THREE.Mesh(geometry, material);
 		this.visual.castShadow = true;
 		this.visual.receiveShadow = true;
 		this.body = new RigidBody(99999);

--- a/public/game/paddleShader.js
+++ b/public/game/paddleShader.js
@@ -1,0 +1,15 @@
+// Paddle shader definitions live here for easy reuse.
+export const paddleVertexShader = `
+	varying vec2 vUv;
+
+	void main() {
+		vUv = uv;
+		gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+	}
+`;
+
+export const paddleFragmentShader = `
+	void main() {
+		gl_FragColor = vec4(0.2, 0.9, 0.2, 1.0);
+	}
+`;


### PR DESCRIPTION
Added a paddle shader module and wired it into the paddle mesh. The paddles now render with a custom ShaderMaterial (vertex + fragment shaders), and the fragment shader outputs a solid color so the effect is clearly visible without any texture/UV pattern.
close #53 