### PR TITLE
DK - created page for users to customize their settings/skins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .env
 .vercel
 node_modules
-/db/pong.db
+db/pong.db*

--- a/src/auth/google.js
+++ b/src/auth/google.js
@@ -1,4 +1,4 @@
-import db from '../db.js';
+import db from '../db/db.js';
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 
@@ -37,9 +37,8 @@ export default function setupGoogleStrategy() {
 
 							if (existingUser) {
 								db.run(
-									`UPDATE users SET email = ?, display_name = ?, avatar_url = ?
-									WHERE google_sub = ?`,
-									[email, displayName, avatarUrl, googleSub],
+									`UPDATE users SET email = ?, avatar_url = ? WHERE google_sub = ?`,
+									[email, avatarUrl, googleSub],
 									(updateErr) => {
 										if (updateErr) return done(updateErr);
 										return done(null, existingUser);

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -1,4 +1,4 @@
-import db from '../db.js';
+import db from '../db/db.js';
 import session from 'express-session';
 import passport from 'passport';
 import setupGoogleStrategy from './google.js';

--- a/src/db/db.js
+++ b/src/db/db.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sqlite3 from 'sqlite3';
 
-const dbPath = path.resolve(import.meta.dirname, '..', 'db', 'pong.db');
+const dbPath = path.resolve(import.meta.dirname, '..', '..', 'db', 'pong.db');
 fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
 const db = new sqlite3.Database(dbPath, (err) => {

--- a/src/db/initializeBallSkins.js
+++ b/src/db/initializeBallSkins.js
@@ -1,0 +1,38 @@
+import db from './db.js';
+
+// TODO: Replace this with real ball skin configs
+const BALL_SKIN_CONFIGS = [
+	{ id: 'classic', displayName: 'Classic', assetKey: 'classic', isDefault: 0 },
+	{
+		id: 'neon_blue',
+		displayName: 'Neon Blue',
+		assetKey: 'neon_blue',
+		isDefault: 0
+	},
+	{
+		id: 'hot_pink',
+		displayName: 'Hot Pink',
+		assetKey: 'hot_pink',
+		isDefault: 0
+	}
+];
+
+export function initializeBallSkins() {
+	BALL_SKIN_CONFIGS.forEach((config) => {
+		db.get(
+			'SELECT 1 FROM items WHERE item_key = ? AND kind = ?',
+			[config.id, 'ball_skin'],
+			(err, row) => {
+				if (err) return console.error(err);
+
+				if (!row) {
+					db.run(
+						`INSERT INTO items (item_key, kind, display_name, asset_key, is_default)
+                         VALUES (?, 'ball_skin', ?, ?, ?)`,
+						[config.id, config.displayName, config.assetKey, config.isDefault]
+					);
+				}
+			}
+		);
+	});
+}

--- a/src/db/initializeGoalExplosions.js
+++ b/src/db/initializeGoalExplosions.js
@@ -1,0 +1,22 @@
+import db from './db.js';
+import { GOAL_EXPLOSION_STYLES } from '../../public/game/shaders/animationConfigRegistry.js';
+
+export function initializeGoalExplosions() {
+    GOAL_EXPLOSION_STYLES.forEach((style) => {
+        db.get(
+            'SELECT 1 FROM items WHERE item_key = ? AND kind = ?',
+            [style.id, 'goal_explosion'],
+            (err, row) => {
+                if (err) return console.error(err);
+
+                if (!row) {
+                    db.run(
+                        `INSERT INTO items (item_key, kind, display_name, asset_key, is_default)
+                         VALUES (?, 'goal_explosion', ?, ?, 0)`,
+                        [style.id, style.label, style.id]
+                    );
+                }
+            }
+        );
+    });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,12 @@ dotenv.config();
 import express from 'express';
 import path from 'path';
 import createLobbyRouter from './lobby/router.js';
+import createUserRouter from './user/router.js';
 import setupAuth from './auth/index.js';
-import './db.js';
+import './db/db.js';
+
+import { initializeGoalExplosions } from './db/initializeGoalExplosions.js';
+import { initializeBallSkins } from './db/initializeBallSkins.js';
 
 const PORT = process.env.PORT || 3000;
 
@@ -18,8 +22,12 @@ app.use(express.static(path.join(import.meta.dirname, '../public')));
 
 setupAuth(app);
 
+initializeGoalExplosions();
+initializeBallSkins();
+
 const server = app.listen(PORT);
 
 app.use('/', createLobbyRouter(server));
+app.use('/user', createUserRouter());
 
 export default app;

--- a/src/lobby/lobbyState.js
+++ b/src/lobby/lobbyState.js
@@ -17,23 +17,6 @@ function generateCode() {
 	return out;
 }
 
-const DEFAULT_COSMETICS = Object.freeze({
-	ball: { skinId: 'classic' }
-});
-
-const ALLOWED_BALL_SKINS = new Set(['classic', 'neon_blue', 'hot_pink']);
-
-function normalizeCosmetics(input) {
-	const skinId = input?.ball?.skinId;
-	return {
-		ball: {
-			skinId: ALLOWED_BALL_SKINS.has(skinId)
-				? skinId
-				: DEFAULT_COSMETICS.ball.skinId
-		}
-	};
-}
-
 export default class LobbyState {
 	#server = null;
 
@@ -48,13 +31,11 @@ export default class LobbyState {
 
 	createLobby(arg = undefined) {
 		let name = 'My Lobby';
-		let cosmetics = undefined;
 
 		if (typeof arg === 'string' || arg === undefined || arg === null) {
 			name = arg ?? 'My Lobby';
 		} else if (typeof arg === 'object') {
 			name = arg.name ?? 'My Lobby';
-			cosmetics = arg.cosmetics;
 		}
 
 		const lobbyId = String(nextLobbyId++);
@@ -62,7 +43,6 @@ export default class LobbyState {
 		const lobby = {
 			lobbyId,
 			name,
-			cosmetics: normalizeCosmetics(cosmetics),
 			members: new Map(),
 			emptySince: Date.now(),
 			code: generateCode()

--- a/src/lobby/router.js
+++ b/src/lobby/router.js
@@ -15,8 +15,7 @@ export default function createLobbyRouter(server) {
 
 	router.post('/api/lobbies', (req, res) => {
 		const name = req.body?.name;
-		const cosmetics = req.body?.cosmetics;
-		const lobby = lobbyState.createLobby({ name, cosmetics });
+		const lobby = lobbyState.createLobby(name);
 		res.json({ lobby });
 	});
 

--- a/src/user/router.js
+++ b/src/user/router.js
@@ -1,0 +1,224 @@
+import express from 'express';
+import db from '../db/db.js';
+
+export default function createUserRouter() {
+	const router = express.Router();
+
+	function ensureAuth(req, res, next) {
+		if (req.isAuthenticated && req.isAuthenticated()) return next();
+		res.status(401).json({ error: 'Unauthorized' });
+	}
+
+	router.get('/', ensureAuth, async (req, res) => {
+		const userId = req.user.id;
+
+		const dbAll = (sql, params = []) =>
+			new Promise((resolve, reject) => {
+				db.all(sql, params, (err, rows) => {
+					if (err) reject(err);
+					else resolve(rows);
+				});
+			});
+
+		const dbGet = (sql, params = []) =>
+			new Promise((resolve, reject) => {
+				db.get(sql, params, (err, row) => {
+					if (err) reject(err);
+					else resolve(row);
+				});
+			});
+
+		try {
+			const goalExplosions = await dbAll(
+				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, u.unlocked_at
+				FROM items i
+				LEFT JOIN user_unlocks u 
+				ON i.id = u.item_id AND u.user_id = ?
+				WHERE i.kind = 'goal_explosion'`,
+				[userId]
+			);
+
+			const ballSkins = await dbAll(
+				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, u.unlocked_at
+				FROM items i
+				LEFT JOIN user_unlocks u
+				ON i.id = u.item_id AND u.user_id = ?
+				WHERE i.kind = 'ball_skin'`,
+				[userId]
+			);
+
+			const unlocks = await dbAll(
+				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, i.is_default, u.unlocked_at
+				FROM items i
+				INNER JOIN user_unlocks u ON i.id = u.item_id
+				WHERE u.user_id = ? AND i.kind != 'goal_explosion'`,
+				[userId]
+			);
+
+			const equipped = await dbGet(
+				`SELECT
+					u.user_id,
+					p.id AS paddle_skin_id, p.item_key AS paddle_skin_key, p.display_name AS paddle_skin_name,
+					b.id AS ball_skin_id, b.item_key AS ball_skin_key, b.display_name AS ball_skin_name,
+					g.id AS goal_explosion_id, g.item_key AS goal_explosion_key, g.display_name AS goal_explosion_name,
+					u.updated_at
+				FROM user_equipped u
+				LEFT JOIN items p ON u.paddle_skin_item_id = p.id
+				LEFT JOIN items b ON u.ball_skin_item_id = b.id
+				LEFT JOIN items g ON u.goal_explosion_item_id = g.id
+				WHERE u.user_id = ?`,
+				[userId]
+			);
+
+			res.render('user', {
+				user: req.user,
+				unlocks,
+				equipped: equipped || {},
+				goalExplosions,
+				ballSkins
+			});
+		} catch (err) {
+			console.error(err);
+			res.status(500).send('Database error');
+		}
+	});
+
+	router.post('/updateDisplayName', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+		const newName = req.body?.display_name?.trim();
+
+		if (!newName) {
+			return res.status(400).json({ ok: false, message: 'Display name cannot be empty' });
+		}
+
+		db.run(
+			`UPDATE users SET display_name = ? WHERE id = ?`,
+			[newName, userId],
+			function (err) {
+				if (err) {
+					console.error('Failed to update display name:', err.message);
+					return res.status(500).json({ ok: false, message: 'Database error' });
+				}
+				req.user.display_name = newName;
+				res.json({ ok: true, display_name: newName });
+			}
+		);
+	});
+
+	router.get('/items/unlocks', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+		const sql = `SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, i.is_default, u.unlocked_at
+        FROM items i
+        INNER JOIN user_unlocks u ON i.id = u.item_id
+        WHERE u.user_id = ?`;
+		db.all(sql, [userId], (err, rows) => {
+			if (err) return res.status(500).json({ error: 'Database error' });
+			res.json(rows);
+		});
+	});
+
+	router.get('/items/equipped', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+		const sql = `SELECT
+			u.user_id,
+			p.id AS paddle_skin_id, p.item_key AS paddle_skin_key, p.display_name AS paddle_skin_name,
+			b.id AS ball_skin_id, b.item_key AS ball_skin_key, b.display_name AS ball_skin_name,
+			g.id AS goal_explosion_id, g.item_key AS goal_explosion_key, g.display_name AS goal_explosion_name,
+			u.updated_at
+		FROM user_equipped u
+		LEFT JOIN items p ON u.paddle_skin_item_id = p.id
+		LEFT JOIN items b ON u.ball_skin_item_id = b.id
+		LEFT JOIN items g ON u.goal_explosion_item_id = g.id
+		WHERE u.user_id = ?`;
+		db.get(sql, [userId], (err, row) => {
+			if (err) return res.status(500).json({ error: 'Database error' });
+			res.json(row || {});
+		});
+	});
+
+	router.post('/items/equipItem', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+		const { itemId, slot } = req.body;
+
+		const validType = ['paddle_skin', 'ball_skin', 'goal_explosion'];
+		if (!validType.includes(slot)) {
+			return res.status(400).json({ ok: false, error: 'Invalid type' });
+		}
+
+		const columnMap = {
+			paddle_skin: 'paddle_skin_item_id',
+			ball_skin: 'ball_skin_item_id',
+			goal_explosion: 'goal_explosion_item_id',
+		};
+		const column = columnMap[slot];
+
+		const sql = `
+			INSERT INTO user_equipped (user_id, ${column})
+			VALUES (?, ?)
+			ON CONFLICT(user_id) DO UPDATE SET
+				${column} = excluded.${column},
+				updated_at = datetime('now')
+		`;
+
+		db.run(sql, [userId, itemId], function (err) {
+			if (err) return res.status(500).json({ ok: false, error: 'Database error' });
+			res.json({ ok: true });
+		});
+	});
+
+	router.post('/debug/unlockRandomGoalExplosion', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+
+		db.get(
+			`SELECT i.id FROM items i
+            WHERE i.kind = 'goal_explosion'
+            AND i.id NOT IN (
+                SELECT item_id FROM user_unlocks WHERE user_id = ?
+            )
+            ORDER BY RANDOM() LIMIT 1`,
+			[userId],
+			(err, row) => {
+				if (err) return res.status(500).json({ error: 'Database error' });
+				if (!row) return res.json({ message: 'All goal explosions already unlocked!' });
+
+				db.run(
+					`INSERT INTO user_unlocks (user_id, item_id, unlocked_at) VALUES (?, ?, CURRENT_TIMESTAMP)`,
+					[userId, row.id],
+					(err2) => {
+						if (err2) return res.status(500).json({ error: 'Database error' });
+						res.json({ message: 'Unlocked a new goal explosion!', itemId: row.id });
+					}
+				);
+			}
+		);
+	});
+
+	router.post('/debug/unlockRandomBallSkin', ensureAuth, (req, res) => {
+		const userId = req.user.id;
+
+		db.get(
+			`SELECT i.id FROM items i
+            WHERE i.kind = 'ball_skin'
+            AND i.id NOT IN (
+                SELECT item_id FROM user_unlocks WHERE user_id = ?
+            )
+            ORDER BY RANDOM() LIMIT 1`,
+			[userId],
+			(err, row) => {
+				if (err) return res.status(500).json({ error: 'Database error' });
+				if (!row) return res.json({ message: 'All ball skins already unlocked!' });
+
+				db.run(
+					`INSERT INTO user_unlocks (user_id, item_id, unlocked_at) VALUES (?, ?, CURRENT_TIMESTAMP)`,
+					[userId, row.id],
+					(err2) => {
+						if (err2) return res.status(500).json({ error: 'Database error' });
+						res.json({ message: 'Unlocked a new ball skin!', itemId: row.id });
+					}
+				);
+			}
+		);
+	});
+
+	return router;
+}

--- a/src/views/lobbies.ejs
+++ b/src/views/lobbies.ejs
@@ -83,8 +83,14 @@
 	<body>
 		<div>
 			<% if (user) { %>
-				<span>Logged in as <%= user.display_name %></span>
-				<button onclick="logout()">Log out</button>
+				<div style="display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem;">
+					<button onclick="window.location='/user'" style="width: auto; padding: 0.5rem 1rem;">
+						Logged in as <%= user.display_name %> — My Profile
+					</button>
+					<button onclick="logout()" style="width: auto; padding: 0.5rem 1rem;">
+						Log out
+					</button>
+				</div>
 			<% } else { %>
 				<a href="/auth/google">Log in with Google</a>
 			<% } %>
@@ -101,14 +107,6 @@
 
 			<div>
 				<input id="name-field" placeholder="Lobby name" style="margin-bottom: 1rem" />
-				<div style="margin-top: 0.5rem">
-					<label for="ball-skin" style="margin-right: 0.5rem">Ball:</label>
-					<select id="ball-skin">
-						<option value="classic" selected>Classic</option>
-						<option value="neon_blue">Neon Blue</option>
-						<option value="hot_pink">Hot Pink</option>
-					</select>
-				</div>
 				<button id="create-button">Create Lobby</button>
 			</div>
 
@@ -138,11 +136,11 @@
 		</div>
 
 		<script>
-			const ballSkinField = document.getElementById('ball-skin');
+			const equippedBallSkin = '<%= user && user.equipped_ball_skin_key ? user.equipped_ball_skin_key : "classic" %>';
 
 			function getSelectedCosmetics() {
 				return {
-					ball: { skinId: ballSkinField?.value || 'classic' }
+					ball: { skinId: equippedBallSkin }
 				};
 			};
 

--- a/src/views/user.ejs
+++ b/src/views/user.ejs
@@ -1,0 +1,236 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title><%= user.display_name || user.email %> • Profile</title>
+	<style>
+		* { box-sizing: border-box; }
+
+		body {
+			margin: 0 auto;
+			padding: 3rem;
+			width: 80ch;
+			max-width: 100%;
+			font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+			color: rgba(255, 255, 255, 0.92);
+			background: linear-gradient(180deg,#0b1020,#0a1226);
+		}
+
+		h1, h2 { margin-top: 0; }
+		h1 { font-size: 3rem; margin-bottom: 1.2rem; }
+
+		.card {
+			background: rgba(255,255,255,.06);
+			border: 0.1rem solid rgba(255,255,255,.10);
+			border-radius: 1.1rem;
+			box-shadow: 0 0.75rem 2.25rem rgba(0,0,0,.35);
+			padding: 1.25rem;
+			margin-bottom: 1rem;
+		}
+
+		.item-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+		.item {
+			border: 0.1rem solid rgba(255,255,255,.18);
+			border-radius: 0.75rem;
+			padding: 0.75rem;
+			background: rgba(255,255,255,.08);
+			min-width: 120px;
+			text-align: center;
+			cursor: pointer;
+			transition: transform .08s, background .15s, opacity .15s;
+		}
+		.item.locked {
+			opacity: 0.35;
+			cursor: not-allowed;
+		}
+		.item:hover:not(.locked) { transform: translateY(-2px); background: rgba(0,229,255,.12); }
+		.avatar { width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem; }
+		button { cursor: pointer; }
+	</style>
+</head>
+<body>
+	<div class="card">
+		<h1>Profile</h1>
+
+		<% if (user.avatar_url) { %>
+			<img src="<%= user.avatar_url %>" alt="Avatar" class="avatar" style="width: 100px; height: 100px; border-radius: 50%; margin-bottom: 1rem;">
+		<% } %>
+
+		<p>
+			<strong>Name:</strong>
+			<input
+				type="text"
+				id="display-name"
+				value="<%= user.display_name || '' %>"
+				placeholder="Enter display name"
+				style="padding: 0.5rem; border-radius: 0.5rem; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.08); color: white; width: 200px;"
+			/>
+			<button id="update-display-name" style="padding: 0.5rem 1rem; border-radius: 0.5rem; margin-left: 0.5rem;">
+				Update Name
+			</button>
+		</p>
+
+		<p id="update-msg" style="color: lightgreen; margin-top: 0.5rem;"></p>
+
+		<p><strong>Email:</strong> <%= user.email %></p>
+	</div>
+
+	<div class="card">
+		<h2>Equipped Items</h2>
+		<div class="item-list">
+			<div class="item">
+				<strong>Paddle Skin:</strong><br>
+				<%= equipped.paddle_skin_key || 'Default Paddle' %>
+			</div>
+			<div class="item" id="equipped-ball-skin" data-label="Ball Skin">
+				<strong>Ball Skin:</strong><br>
+				<%= equipped.ball_skin_name || 'Default Ball' %>
+			</div>
+			<div class="item" id="equipped-goal-explosion" data-label="Goal Explosion">
+				<strong>Goal Explosion:</strong><br>
+				<%= equipped.goal_explosion_name || 'Default Goal' %>
+			</div>
+		</div>
+	</div>
+
+	<div class="card">
+		<h2>Ball Skins</h2>
+		<% if (ballSkins.length > 0) { %>
+			<div class="item-list" id="ball-skins">
+				<% ballSkins.forEach(skin => { %>
+					<div class="item <%= skin.unlocked_at ? '' : 'locked' %>" data-item-id="<%= skin.id %>">
+						<strong><%= skin.display_name %></strong><br>
+						<%= skin.unlocked_at ? '✅ Unlocked' : '🔒 Locked' %>
+					</div>
+				<% }) %>
+			</div>
+		<% } else { %>
+			<p>No ball skins available.</p>
+		<% } %>
+	</div>
+
+	<div class="card">
+		<h2>Goal Explosions</h2>
+		<% if (goalExplosions.length > 0) { %>
+			<div class="item-list" id="goal-explosions">
+				<% goalExplosions.forEach(exp => { %>
+					<div class="item <%= exp.unlocked_at ? '' : 'locked' %>" data-item-id="<%= exp.id %>">
+						<strong><%= exp.display_name %></strong><br>
+						<%= exp.unlocked_at ? '✅ Unlocked' : '🔒 Locked' %>
+					</div>
+				<% }) %>
+			</div>
+		<% } else { %>
+			<p>No goal explosions available.</p>
+		<% } %>
+	</div>
+
+	<div style="margin-top:1rem; text-align:center; display: flex; gap: 0.5rem; justify-content: center;">
+		<button id="debug-unlock-ball" style="padding:0.5rem 1rem; border-radius:0.5rem;">
+			Debug: Unlock Random Ball Skin
+		</button>
+		<button id="debug-unlock-goal" style="padding:0.5rem 1rem; border-radius:0.5rem;">
+			Debug: Unlock Random Goal Explosion
+		</button>
+	</div>
+
+	<script>
+		function equipItem(el, slot, displayEl) {
+			el.addEventListener('click', () => {
+				if (el.classList.contains('locked')) return;
+
+				const itemId = el.dataset.itemId;
+				const name = el.querySelector('strong').innerText;
+
+				fetch('/user/items/equipItem', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					credentials: 'same-origin',
+					body: JSON.stringify({ itemId, slot })
+				})
+				.then(res => res.json())
+				.then(data => {
+					if (data.ok) {
+						displayEl.innerHTML = `<strong>${displayEl.dataset.label}:</strong><br>${name}`;
+						const container = el.closest('.item-list');
+						container.querySelectorAll('.item').forEach(i => i.style.borderColor = 'rgba(255,255,255,.18)');
+						el.style.borderColor = 'rgb(0, 229, 255)';
+					}
+				});
+			});
+		}
+
+		document.querySelectorAll('#ball-skins .item').forEach(el => equipItem(el, 'ball_skin', document.getElementById('equipped-ball-skin')));
+		document.querySelectorAll('#goal-explosions .item').forEach(el => equipItem(el, 'goal_explosion', document.getElementById('equipped-goal-explosion')));
+
+		document.getElementById('debug-unlock-ball')?.addEventListener('click', () => {
+			fetch('/user/debug/unlockRandomBallSkin', {
+				method: 'POST',
+				credentials: 'same-origin'
+			})
+			.then(res => res.json())
+			.then(data => {
+				alert(data.message);
+				window.location.reload();
+			});
+		});
+
+		document.getElementById('debug-unlock-goal')?.addEventListener('click', () => {
+			fetch('/user/debug/unlockRandomGoalExplosion', {
+				method: 'POST',
+				credentials: 'same-origin'
+			})
+			.then(res => res.json())
+			.then(data => {
+				alert(data.message);
+				window.location.reload();
+			});
+		});
+
+		const equippedBallSkinName = '<%= equipped.ball_skin_name || "" %>';
+		document.querySelectorAll('#ball-skins .item').forEach(el => {
+			if (el.querySelector('strong').innerText === equippedBallSkinName) {
+				el.style.borderColor = 'rgb(0, 229, 255)';
+			}
+		});
+
+		const equippedGoalName = '<%= equipped.goal_explosion_name || "" %>';
+		document.querySelectorAll('#goal-explosions .item').forEach(el => {
+			if (el.querySelector('strong').innerText === equippedGoalName) {
+				el.style.borderColor = 'rgb(0, 229, 255)';
+			}
+		});
+
+		document.getElementById('update-display-name').addEventListener('click', async () => {
+			const input = document.getElementById('display-name');
+			const newName = input.value.trim();
+			const msg = document.getElementById('update-msg');
+
+			if (!newName) {
+				msg.style.color = 'red';
+				msg.textContent = 'Display name cannot be empty.';
+				return;
+			}
+
+			try {
+				const res = await fetch('/user/updateDisplayName', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ display_name: newName })
+				});
+
+				if (!res.ok) {
+					const data = await res.json();
+					throw new Error(data?.message || 'Failed to update display name.');
+				}
+
+				msg.style.color = 'lightgreen';
+				msg.textContent = `Display name updated successfully to ${newName}!`;
+			} catch (err) {
+				msg.style.color = 'red';
+				msg.textContent = err.message;
+			}
+		});
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #84 

Added a page for user profile updates and skin selection.

### `user/router.js` features
- `GET /`: Fetch all information about a user, such as display name, email address, unlocked items, and equipped items
- `POST /updateDisplayName`: Users can update their display name
- `GET /items/unlocks`: Fetch the list of all unlocked items for a user
- `GET /items/equipped`: Fetch the list of currently equipped items (paddle, ball, goal)
- `POST /items/equipItem`: Equip an item the user has unlocked

### `views/user.ejs` features
This page utilizes the endpoints listed above. The page can be accessed after the user logged in with Google OAuth.
Users can select and equip items they've unlocked. For now, there is a debug button that will unlock you a random item.

### Notes
- `src/db.js` has been moved to `src/db/db.js` for organization
- `src/db` has `initializeBallSkins.js` and `initializeGoalExplosions.js` which help initialize items
- Previously, logging in with Google reloaded the user's information. Now, `displayName` is excluded from the reload for persistence of customized display names
- Removed all ball skin and cosmetics options from the lobby system

### Images
<img width="311" height="617" alt="image" src="https://github.com/user-attachments/assets/66946b58-e557-4983-a689-a31bf3adb538" />
