### PR TITLE
jp - fixed GoalExplosionDemo scene

### DIFF
--- a/public/game/goalExplosionDemo.js
+++ b/public/game/goalExplosionDemo.js
@@ -205,7 +205,7 @@ function createGradientSkybox() {
 		`,
 		uniforms: {
 			topColor: { value: new THREE.Color(0x0b2247) },
-			midColor: { value: new THREE.Color(0x7fb9f0) },
+			midColor: { value: new THREE.Color(0x16215e) },
 			botColor: { value: new THREE.Color(0x3e6fa0) },
 		},
 		side: THREE.BackSide,
@@ -213,6 +213,5 @@ function createGradientSkybox() {
 	});
 
 	const sky = new THREE.Mesh(geometry, material);
-	sky.frustumCulled = false;
 	return sky;
 }


### PR DESCRIPTION
Remade the goal explosion demo scene to work with the new animated scene. Simplified it, added color picker support, and added a basic skybox.
<img width="1461" height="817" alt="image" src="https://github.com/user-attachments/assets/dfd0b23e-9c72-4740-babe-b70a5aa02a6e" />
