### PR TITLE
TZ - add kick, transfer host, private

### DIFF
--- a/public/lobbies.css
+++ b/public/lobbies.css
@@ -15,6 +15,7 @@
 	align-items: center;
 	justify-content: space-between;
 	color: rgba(255, 255, 255, 0.92);
+	margin-bottom: 1rem;
 }
 
 .visibility-buttons {
@@ -31,6 +32,16 @@
 	box-shadow: none;
 }
 
+.visibility-button:hover:not(:disabled) {
+	background: rgba(255, 255, 255, 0.2);
+	transform: translateY(-1px);
+}
+
+.visibility-button:active {
+	border-style: solid;
+}
+
 .visibility-button.active {
 	background: rgba(255, 255, 255, 0.3);
+	border-style: solid;
 }

--- a/public/main.js
+++ b/public/main.js
@@ -117,8 +117,6 @@ animatedScene.registerGameObject(
 		startButton: document.getElementById('startButton'),
 		leaveLobbyButton: document.getElementById('waiting__leaveButton'),
 		players: animatedScene.state.players,
-		lobbyMembers: [],
-		isPublic: true,
 		socket,
 		init() {
 			this.startButton.addEventListener('click', () => {

--- a/public/socket.js
+++ b/public/socket.js
@@ -4,7 +4,6 @@ export default class PongSocketClient {
 	#pingInterval = null;
 	#lastPingTs = null;
 	#lastLatencyMs = null;
-	#manualClose = false;
 
 	#handlers = new Map();
 
@@ -14,7 +13,6 @@ export default class PongSocketClient {
 	}
 
 	connect() {
-		this.#manualClose = false;
 		if (this.#reconnectTimer) {
 			clearTimeout(this.#reconnectTimer);
 			this.#reconnectTimer = null;

--- a/src/lobby/lobbyState.js
+++ b/src/lobby/lobbyState.js
@@ -30,17 +30,7 @@ export default class LobbyState {
 		this.sockets = new Map();
 	}
 
-	createLobby(arg = undefined) {
-		let name = 'My Lobby';
-		let isPublic = true;
-
-		if (typeof arg === 'string' || arg === undefined || arg === null) {
-			name = arg ?? 'My Lobby';
-		} else if (typeof arg === 'object') {
-			name = arg.name ?? 'My Lobby';
-			if (typeof arg.isPublic === 'boolean') isPublic = arg.isPublic;
-		}
-
+	createLobby(name, isPublic) {
 		const lobbyId = String(nextLobbyId++);
 
 		const lobby = {

--- a/src/lobby/router.js
+++ b/src/lobby/router.js
@@ -10,10 +10,11 @@ export default function createLobbyRouter(server, parseSession) {
 	});
 
 	router.post('/api/lobbies', (req, res) => {
+		if (!req.user) return res.sendStatus(401);
+
 		const name = req.body?.name ?? `${req.user.display_name}’s lobby`;
 		const isPublic = req.body?.isPublic;
-		const lobby = lobbyState.createLobby({ name, isPublic });
-		if (!req.user) return res.sendStatus(401);
+		const lobby = lobbyState.createLobby(name, isPublic);
 
 		res.json({ lobby });
 	});

--- a/src/views/lobbies.ejs
+++ b/src/views/lobbies.ejs
@@ -26,15 +26,15 @@
 			<h1>Lobbies</h1>
 
 			<div class="card" style="display: flex; flex-direction: column; gap: 1.5rem;">
-				<div class="visibility-picker">
-					<span>Lobby visibility</span>
-					<div class="visibility-buttons">
-						<button id="create-public-button" class="visibility-button active">Public</button>
-						<button id="create-private-button" class="visibility-button">Private</button>
-					</div>
-				</div>
 				<div>
 					<input id="name-field" placeholder="Lobby name" style="display: block; width: 100%; margin-bottom: 1rem" />
+					<div class="visibility-picker">
+						<span>Lobby visibility</span>
+						<div class="visibility-buttons">
+							<button id="create-public-button" class="visibility-button active">Public</button>
+							<button id="create-private-button" class="visibility-button">Private</button>
+						</div>
+					</div>
 					<button id="create-button" style="display: block; width: 100%">Create Lobby</button>
 				</div>
 


### PR DESCRIPTION
I added host controls and stable host handoff for lobbies: the host can kick players, change lobby visibility with Public/Private buttons (default Public), and every player (including host) can leave via Leave Game; host labels are shown in the UI, and kick controls exist in both waiting room and in-game views.
close #96 