### PR TITLE
Jp - db items table unique fix & asset_key removal

### DIFF
--- a/src/db/db.js
+++ b/src/db/db.js
@@ -35,12 +35,12 @@ db.serialize(() => {
 	db.run(
 		`CREATE TABLE IF NOT EXISTS items (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			item_key TEXT NOT NULL UNIQUE,
+			item_key TEXT NOT NULL,
 			kind TEXT NOT NULL CHECK (kind IN ('paddle_skin', 'ball_skin', 'goal_explosion')),
 			display_name TEXT NOT NULL,
-			asset_key TEXT NOT NULL,
 			is_default INTEGER NOT NULL DEFAULT 0,
-			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			UNIQUE (item_key, kind)
 		)`,
 		(err) => {
 			if (err) console.error('Table creation failed:', err.message);

--- a/src/db/initializeBallSkins.js
+++ b/src/db/initializeBallSkins.js
@@ -2,17 +2,15 @@ import db from './db.js';
 
 // TODO: Replace this with real ball skin configs
 const BALL_SKIN_CONFIGS = [
-	{ id: 'classic', displayName: 'Classic', assetKey: 'classic', isDefault: 0 },
+	{ id: '0', displayName: 'Classic', isDefault: 0 },
 	{
-		id: 'neon_blue',
+		id: '1',
 		displayName: 'Neon Blue',
-		assetKey: 'neon_blue',
 		isDefault: 0
 	},
 	{
-		id: 'hot_pink',
+		id: '2',
 		displayName: 'Hot Pink',
-		assetKey: 'hot_pink',
 		isDefault: 0
 	}
 ];
@@ -27,9 +25,9 @@ export function initializeBallSkins() {
 
 				if (!row) {
 					db.run(
-						`INSERT INTO items (item_key, kind, display_name, asset_key, is_default)
-                         VALUES (?, 'ball_skin', ?, ?, ?)`,
-						[config.id, config.displayName, config.assetKey, config.isDefault]
+						`INSERT INTO items (item_key, kind, display_name, is_default)
+                         VALUES (?, 'ball_skin', ?, ?)`,
+						[config.id, config.displayName, config.isDefault]
 					);
 				}
 			}

--- a/src/db/initializeGoalExplosions.js
+++ b/src/db/initializeGoalExplosions.js
@@ -11,9 +11,9 @@ export function initializeGoalExplosions() {
 
 				if (!row) {
 					db.run(
-						`INSERT INTO items (item_key, kind, display_name, asset_key, is_default)
-                         VALUES (?, 'goal_explosion', ?, ?, 0)`,
-						[style.styleIndex, style.label, style.styleIndex]
+						`INSERT INTO items (item_key, kind, display_name, is_default)
+                         VALUES (?, 'goal_explosion', ?, 0)`,
+						[style.styleIndex, style.label]
 					);
 				}
 			}

--- a/src/user/router.js
+++ b/src/user/router.js
@@ -30,7 +30,7 @@ export default function createUserRouter() {
 
 		try {
 			const goalExplosions = await dbAll(
-				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, u.unlocked_at
+				`SELECT i.id, i.item_key, i.kind, i.display_name, u.unlocked_at
 				FROM items i
 				LEFT JOIN user_unlocks u 
 				ON i.id = u.item_id AND u.user_id = ?
@@ -39,7 +39,7 @@ export default function createUserRouter() {
 			);
 
 			const ballSkins = await dbAll(
-				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, u.unlocked_at
+				`SELECT i.id, i.item_key, i.kind, i.display_name, u.unlocked_at
 				FROM items i
 				LEFT JOIN user_unlocks u
 				ON i.id = u.item_id AND u.user_id = ?
@@ -48,7 +48,7 @@ export default function createUserRouter() {
 			);
 
 			const unlocks = await dbAll(
-				`SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, i.is_default, u.unlocked_at
+				`SELECT i.id, i.item_key, i.kind, i.display_name, i.is_default, u.unlocked_at
 				FROM items i
 				INNER JOIN user_unlocks u ON i.id = u.item_id
 				WHERE u.user_id = ? AND i.kind != 'goal_explosion'`,
@@ -109,7 +109,7 @@ export default function createUserRouter() {
 
 	router.get('/items/unlocks', ensureAuth, (req, res) => {
 		const userId = req.user.id;
-		const sql = `SELECT i.id, i.item_key, i.kind, i.display_name, i.asset_key, i.is_default, u.unlocked_at
+		const sql = `SELECT i.id, i.item_key, i.kind, i.display_name, i.is_default, u.unlocked_at
         FROM items i
         INNER JOIN user_unlocks u ON i.id = u.item_id
         WHERE u.user_id = ?`;


### PR DESCRIPTION

Modifes the Unique constraint on the items table to be on item_key AND kind, rather than just on item_key. This fixes an issue where mutliple items of different kinds but the same item_key would have collisions.

Removes asset_key from items_table. This no longer has a purpose in the current design.